### PR TITLE
feat: add an schema for an array of invoices

### DIFF
--- a/invoice-array.schema.json
+++ b/invoice-array.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "title": "A List of Simple Invoices",
+  "minItems": 1,
+  "items" : {
+    "$ref": "https://raw.githubusercontent.com/quotidian-ennui/fantastic-octo-parakeet/main/invoice-standalone.schema.json"
+  }
+}


### PR DESCRIPTION
As a simple implementation with `$ref`; 

let's just have a schema that declares an array but references back to invoice-standalone.

- This should validate
```json
[{
  "invoice" : {
    "invnumber" : "10001",
    "invdate" : "2001-04-19",
    "customer" : {
      "name" : "Coyote Group, LLC",
      "street" : "3108 Suspendisse Ave",
      "city" : "Berlin",
      "state" : "New South Wales",
      "zip" : "37337",
      "phone" : "1-987-649-5599",
      "attn" : "Wile E. Coyote"
    },
    "items" : {
      "item" : [ {
        "date" : "2001-04-01",
        "description" : "Anvil",
        "quantity" : "1",
        "unitprice" : "50.00"
      }]
    }
  }
}]
```

- This should not because minItems=1
```json
[]
```